### PR TITLE
Use alpine names for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ addons:
 
 env:
   matrix:
-    - DOCKER_TAG=9.6
-    - DOCKER_TAG=10
-    - DOCKER_TAG=11
-    - DOCKER_TAG=latest
+    - DOCKER_TAG=9.6-alpine
+    - DOCKER_TAG=10-alpine
+    - DOCKER_TAG=11-alpine
+    - DOCKER_TAG=alpine
 
 install:
   - pip install -r tests/ci-requirements.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "program": "${file}",
             "console": "integratedTerminal",
             "env": {
-                "DOCKER_TAG": "latest",
+                "DOCKER_TAG": "alpine",
             },
         },
     ]

--- a/hooks/build
+++ b/hooks/build
@@ -6,17 +6,12 @@ test -n "$DOCKER_TAG"
 
 # Prepare build args
 commit="${GIT_SHA1:-$TRAVIS_COMMIT}"
-if [ "$DOCKER_TAG" == "latest" ]; then
-    base_tag="alpine"
-else
-    base_tag="$DOCKER_TAG-alpine"
-fi
 
 # To be configured via Docker Hub UI, all labels from postgres image targeting
 # this master branch
 time docker image build \
     --build-arg VCS_REF="$commit" \
     --build-arg BUILD_DATE="$(date --rfc-3339 ns)" \
-    --build-arg BASE_TAG="$base_tag" \
+    --build-arg BASE_TAG="$DOCKER_TAG" \
     --tag "tecnativa/postgres-autoconf:$DOCKER_TAG" \
     .


### PR DESCRIPTION

Do not guess the tag; be explicit instead. The tags in this repo will have to include the `alpine` name too, to be a drop-in replacement for upstreams.