### PR TITLE
Allow to pass falsy cert values

### DIFF
--- a/autoconf-entrypoint
+++ b/autoconf-entrypoint
@@ -66,7 +66,7 @@ def permissions_fix(filename):
 for key, filename in SUPPORTED_CERTS.items():
     full_path = os.path.join(CONF_FOLDER, filename)
     # Write PEM file if it came from env variable
-    if not os.path.exists(full_path) and filename in CERTS:
+    if not os.path.exists(full_path) and CERTS.get(filename):
         with open(full_path, "w") as cert_file:
             cert_file.write(CERTS[filename])
     if os.path.exists(full_path):


### PR DESCRIPTION

This way, a falsy value will be the same as no value for a given cert file. It's easier for deployment tools that use this JSON.