### PR TITLE
Avoid using hostssl without certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Method required to authenticate clients that connect from WAN.
 
 #### `WAN_CONNECTION`
 
-Connection type allowed for WAN connections.
+Connection type allowed for WAN connections. If it is `hostssl`, it will only have effect when the required certs are received.
 
 #### `WAN_DATABASES`
 

--- a/autoconf-entrypoint
+++ b/autoconf-entrypoint
@@ -101,14 +101,15 @@ for interface in netifaces.interfaces():
                     ))
 
 # Generate WAN auth configuration
-for user, db, cidr in product(WAN_USERS, WAN_DATABASES, WAN_CIDRS):
-    hba_conf.append(WAN_HBA_TPL.format(
-        connection=WAN_CONNECTION,
-        db=db,
-        user=user,
-        cidr=cidr,
-        meth=WAN_AUTH_METHOD,
-    ))
+if WAN_CONNECTION != "hostssl" or ssl_conf:
+    for user, db, cidr in product(WAN_USERS, WAN_DATABASES, WAN_CIDRS):
+        hba_conf.append(WAN_HBA_TPL.format(
+            connection=WAN_CONNECTION,
+            db=db,
+            user=user,
+            cidr=cidr,
+            meth=WAN_AUTH_METHOD,
+        ))
 
 # Write postgres configuration files
 with open(CONF_FILE, "w") as conf_file:


### PR DESCRIPTION

The default value is a dangerous one as a drop-in replacement for the official postgres image. It produces these errors:

```
LOG:  hostssl requires SSL to be turned on
HINT:  Set ssl = on in postgresql.conf.
CONTEXT:  line 10 of configuration file "/etc/postgres/pg_hba.conf"
FATAL:  could not load pg_hba.conf
LOG:  database system is shut down
```

To avoid that problem, no `hostssl` entries are created if there are no certs.