### PR TITLE
Add pre-commit; lint & deploy from travis; add Postgres 12

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{md,yml}]
+[*.{md,yaml,yml}]
 indent_size = 2

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,12 @@
+# From https://github.com/OCA/maintainer-quality-tools/blob/master/sample_files/pre-commit-13.0/.isort.cfg
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+use_parentheses=True
+line_length=88
+known_odoo=odoo
+known_odoo_addons=odoo.addons
+sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
+known_third_party=plumbum

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+default_language_version:
+  python: python3
+repos:
+- repo: https://github.com/psf/black
+  rev: 19.3b0
+  hooks:
+  - id: black
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: debug-statements
+  - id: fix-encoding-pragma
+    args: ["--remove"]
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-xml
+  - id: mixed-line-ending
+    args: ["--fix=lf"]
+- repo: https://github.com/asottile/seed-isort-config
+  rev: v1.9.3
+  hooks:
+  - id: seed-isort-config
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
+  hooks:
+  - id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,13 @@ stages:
 
 env:
   global:
-    - LATEST_RELEASE=11-alpine
+    - LATEST_RELEASE=12-alpine
     - DOCKER_REPO=tecnativa/postgres-autoconf
   jobs:
     - DOCKER_TAG=9.6-alpine
     - DOCKER_TAG=10-alpine
     - DOCKER_TAG=11-alpine
+    - DOCKER_TAG=12-alpine
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-dist: xenial
-
-sudo: required
+os: linux
 
 language: python
 
@@ -19,19 +17,42 @@ addons:
     packages:
       - docker-ce
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/pre-commit
+
 branches:
   only:
     - master
 
+stages:
+  - name: lint
+  - name: test
+
 env:
-  matrix:
+  global:
+    - LATEST_RELEASE=11-alpine
+    - DOCKER_REPO=tecnativa/postgres-autoconf
+  jobs:
     - DOCKER_TAG=9.6-alpine
     - DOCKER_TAG=10-alpine
     - DOCKER_TAG=11-alpine
-    - DOCKER_TAG=alpine
+
+jobs:
+  include:
+    stage: lint
+    script:
+      - pre-commit run --all --show-diff-on-failure
 
 install:
   - pip install -r tests/ci-requirements.txt
 
 script:
   - ./tests/test.py -v
+
+deploy:
+  provider: script
+  script: ./hooks/push
+  on:
+    branch: master

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "[python]": {
+        "editor.formatOnSave": true,
+    },
+    "editor.formatOnSaveTimeout": 2000,
+    "python.autoComplete.extraPaths": [
+        "./tests",
+    ],
+    "python.formatting.provider": "black",
+    "python.linting.flake8Enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.pythonPath": "python3",
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_TAG
 FROM docker.io/postgres:${BASE_TAG}
 ENTRYPOINT [ "/autoconf-entrypoint" ]
+CMD []
 ENV CERTS="{}" \
     CONF_EXTRA="" \
     LAN_AUTH_METHOD=md5 \

--- a/autoconf-entrypoint
+++ b/autoconf-entrypoint
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-import os
-import json
-import sys
-import netifaces
 import ipaddress
+import json
+import os
 import shutil
 import stat
-
+import sys
 from itertools import product
+
+import netifaces
 
 SUPPORTED_CERTS = {
     "ssl_ca_file": "client.ca.cert.pem",
@@ -85,53 +85,50 @@ for interface in netifaces.interfaces():
                 try:
                     # Format interface IP and netmask in common CIDR notation
                     cidr = ipaddress.ip_network(
-                        "{addr}/{netmask}".format(**address),
-                        False,
+                        "{addr}/{netmask}".format(**address), False
                     )
                 except ValueError:
                     continue
                 # Append line to pg_hba.conf, according to template
                 for user, db in product(LAN_USERS, LAN_DATABASES):
-                    hba_conf.append(LAN_HBA_TPL.format(
-                        connection=LAN_CONNECTION,
-                        db=db,
-                        user=user,
-                        cidr=cidr,
-                        meth=LAN_AUTH_METHOD,
-                    ))
+                    hba_conf.append(
+                        LAN_HBA_TPL.format(
+                            connection=LAN_CONNECTION,
+                            db=db,
+                            user=user,
+                            cidr=cidr,
+                            meth=LAN_AUTH_METHOD,
+                        )
+                    )
 
 # Generate WAN auth configuration
 if WAN_CONNECTION != "hostssl" or ssl_conf:
     for user, db, cidr in product(WAN_USERS, WAN_DATABASES, WAN_CIDRS):
-        hba_conf.append(WAN_HBA_TPL.format(
-            connection=WAN_CONNECTION,
-            db=db,
-            user=user,
-            cidr=cidr,
-            meth=WAN_AUTH_METHOD,
-        ))
+        hba_conf.append(
+            WAN_HBA_TPL.format(
+                connection=WAN_CONNECTION,
+                db=db,
+                user=user,
+                cidr=cidr,
+                meth=WAN_AUTH_METHOD,
+            )
+        )
 
 # Write postgres configuration files
 with open(CONF_FILE, "w") as conf_file:
-    conf_file.write(CONF_TPL.format(
-        conf_folder=CONF_FOLDER,
-        ssl_conf="\n".join(ssl_conf),
-        extra_conf=CONF_EXTRA,
-    ))
+    conf_file.write(
+        CONF_TPL.format(
+            conf_folder=CONF_FOLDER, ssl_conf="\n".join(ssl_conf), extra_conf=CONF_EXTRA
+        )
+    )
 permissions_fix(CONF_FILE)
 with open(HBA_FILE, "w") as conf_file:
-    conf_file.write(HBA_TPL.format(
-        extra_conf="\n".join(hba_conf),
-    ))
+    conf_file.write(HBA_TPL.format(extra_conf="\n".join(hba_conf)))
 permissions_fix(HBA_FILE)
 
 # Continue normal execution
 args = sys.argv[1:]
 if not args or args[0] == "postgres" or args[0].startswith("-"):
     # Need to go through parent image entrypoint, and hardcode conf file
-    args = [
-        "/docker-entrypoint.sh",
-        *args,
-        "-cconfig_file={}".format(CONF_FILE),
-    ]
+    args = ["/docker-entrypoint.sh", *args, "-cconfig_file={}".format(CONF_FILE)]
 os.execvp(args[0], args)

--- a/autoconf-entrypoint
+++ b/autoconf-entrypoint
@@ -130,5 +130,9 @@ permissions_fix(HBA_FILE)
 args = sys.argv[1:]
 if not args or args[0] == "postgres" or args[0].startswith("-"):
     # Need to go through parent image entrypoint, and hardcode conf file
-    args = ["/docker-entrypoint.sh", *args, "-cconfig_file={}".format(CONF_FILE)]
+    args = [
+        "/usr/local/bin/docker-entrypoint.sh",
+        *args,
+        "-cconfig_file={}".format(CONF_FILE),
+    ]
 os.execvp(args[0], args)

--- a/hooks/build
+++ b/hooks/build
@@ -1,17 +1,23 @@
-#!/usr/bin/env bash
-set -ex
+#!/usr/bin/env python3
+from plumbum import FG, local
+from plumbum.cmd import date, docker
 
 # Check environment variables are present
-test -n "$DOCKER_TAG"
+DOCKER_TAG = local.env["DOCKER_TAG"]
+COMMIT = local.env.get("GIT_SHA1", local.env.get("TRAVIS_COMMIT"))
+DATE = date("--rfc-3339", "ns")
 
-# Prepare build args
-commit="${GIT_SHA1:-$TRAVIS_COMMIT}"
-
-# To be configured via Docker Hub UI, all labels from postgres image targeting
-# this master branch
-time docker image build \
-    --build-arg VCS_REF="$commit" \
-    --build-arg BUILD_DATE="$(date --rfc-3339 ns)" \
-    --build-arg BASE_TAG="$DOCKER_TAG" \
-    --tag "tecnativa/postgres-autoconf:$DOCKER_TAG" \
-    .
+# Build image
+docker[
+    "image",
+    "build",
+    "--build-arg",
+    "VCS_REF={}".format(COMMIT),
+    "--build-arg",
+    "BUILD_DATE={}".format(DATE),
+    "--build-arg",
+    "BASE_TAG={}".format(DOCKER_TAG),
+    "--tag",
+    "tecnativa/postgres-autoconf:{}".format(DOCKER_TAG),
+    ".",
+] & FG

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from plumbum import FG, local
+from plumbum.cmd import docker
+
+REPO = local.env["DOCKER_REPO"]
+VERSION = local.env["DOCKER_TAG"]
+
+# Log all locally available images; will help to pin images
+docker["image", "ls", "--digests", REPO] & FG
+
+# Login in Docker Hub
+docker(
+    "login",
+    "--username",
+    local.env["DOCKER_HUB_USERNAME"],
+    "--password",
+    local.env["DOCKER_HUB_TOKEN"],
+)
+
+# Push built images
+versioned_image = "%s:%s" % (REPO, VERSION)
+docker["image", "push", versioned_image] & FG
+if VERSION == local.env.get("LATEST_RELEASE"):
+    latest_version = "alpine" if VERSION.endswith("-alpine") else "latest"
+    latest_image = "%s:%s" % (REPO, latest_version)
+    docker["image", "tag", versioned_image, latest_image] & FG
+    docker["image", "push", latest_image] & FG

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore =
+    # Line too long
+    E501

--- a/tests/certgen
+++ b/tests/certgen
@@ -43,4 +43,3 @@ openssl x509 -req -in client.csr.pem -text -days 3650 \
 chmod u=rw,go= *.pem
 # Delete CSR, no longer needed
 rm *.csr.pem
-

--- a/tests/ci-requirements.txt
+++ b/tests/ci-requirements.txt
@@ -1,1 +1,2 @@
 plumbum
+pre-commit

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,7 +5,7 @@ import time
 import unittest
 
 from plumbum import FG, local
-from plumbum.cmd import cat, docker
+from plumbum.cmd import cat, docker  # pylint: disable=import-error
 from plumbum.commands.processes import ProcessExecutionError
 
 # Make sure all paths are relative to tests dir

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,6 +15,7 @@ certgen = local["./certgen"]
 
 class PostgresAutoconfCase(unittest.TestCase):
     """Test behavior for this docker image"""
+
     def setUp(self):
         with local.cwd(local.cwd / ".."):
             print("Building image")
@@ -22,12 +23,8 @@ class PostgresAutoconfCase(unittest.TestCase):
         docker("network", "create", "lan")
         docker("network", "create", "wan")
         self.version = os.environ["DOCKER_TAG"]
-        self.image = "tecnativa/postgres-autoconf:{}".format(self.version),
-        self.cert_files = {
-            "client.ca.cert.pem",
-            "server.cert.pem",
-            "server.key.pem",
-        }
+        self.image = ("tecnativa/postgres-autoconf:{}".format(self.version),)
+        self.cert_files = {"client.ca.cert.pem", "server.cert.pem", "server.key.pem"}
         return super().setUp()
 
     def tearDown(self):
@@ -52,14 +49,23 @@ class PostgresAutoconfCase(unittest.TestCase):
             try:
                 time.sleep(5)
                 # Test local connections via unix socket work
-                self.assertEqual("1\n", docker(
-                    "container", "exec", self.postgres_container, "psql",
-                    "--command", "SELECT 1",
-                    "--dbname", "test_db",
-                    "--no-align",
-                    "--tuples-only",
-                    "--username", "test_user",
-                ))
+                self.assertEqual(
+                    "1\n",
+                    docker(
+                        "container",
+                        "exec",
+                        self.postgres_container,
+                        "psql",
+                        "--command",
+                        "SELECT 1",
+                        "--dbname",
+                        "test_db",
+                        "--no-align",
+                        "--tuples-only",
+                        "--username",
+                        "test_user",
+                    ),
+                )
             except AssertionError:
                 if attempt < 9:
                     print("Failure number {}. Retrying...".format(attempt))
@@ -73,48 +79,70 @@ class PostgresAutoconfCase(unittest.TestCase):
         if not host:
             # Connect via LAN by default
             host = self.postgres_container[:12]
-        self.assertEqual("1\n", docker(
-            "container", "run",
-            "--network", "lan",
-            "-e", "PGDATABASE=test_db",
-            "-e", "PGPASSWORD=test_password",
-            "-e", "PGSSLMODE=disable",
-            "-e", "PGUSER=test_user",
-            self.image, "psql",
-            "--host", host,
-            "--command", "SELECT 1",
-            "--no-align",
-            "--tuples-only",
-        ))
+        self.assertEqual(
+            "1\n",
+            docker(
+                "container",
+                "run",
+                "--network",
+                "lan",
+                "-e",
+                "PGDATABASE=test_db",
+                "-e",
+                "PGPASSWORD=test_password",
+                "-e",
+                "PGSSLMODE=disable",
+                "-e",
+                "PGUSER=test_user",
+                self.image,
+                "psql",
+                "--host",
+                host,
+                "--command",
+                "SELECT 1",
+                "--no-align",
+                "--tuples-only",
+            ),
+        )
 
     def _connect_wan_network(self, alias="example.com"):
         """Bind a new network, to imitate WAN connections."""
-        docker(
-            "network", "connect",
-            "--alias", alias,
-            "wan",
-            self.postgres_container,
-        )
+        docker("network", "connect", "--alias", alias, "wan", self.postgres_container)
 
     def _check_cert_auth(self):
         """Test connection with cert auth work fine."""
         # Test connection with cert auth works fine
-        self.assertEqual("1\n", docker(
-            "container", "run",
-            "--network", "wan",
-            "-e", "PGDATABASE=test_db",
-            "-e", "PGSSLCERT=/certs/client.cert.pem",
-            "-e", "PGSSLKEY=/certs/client.key.pem",
-            "-e", "PGSSLMODE=verify-full",
-            "-e", "PGSSLROOTCERT=/certs/server.ca.cert.pem",
-            "-e", "PGUSER=test_user",
-            "-v", "{}:/certs".format(local.cwd),
-            self.image, "psql",
-            "--host", "example.com",
-            "--command", "SELECT 1",
-            "--no-align",
-            "--tuples-only",
-        ))
+        self.assertEqual(
+            "1\n",
+            docker(
+                "container",
+                "run",
+                "--network",
+                "wan",
+                "-e",
+                "PGDATABASE=test_db",
+                "-e",
+                "PGSSLCERT=/certs/client.cert.pem",
+                "-e",
+                "PGSSLKEY=/certs/client.key.pem",
+                "-e",
+                "PGSSLMODE=verify-full",
+                "-e",
+                "PGSSLROOTCERT=/certs/server.ca.cert.pem",
+                "-e",
+                "PGUSER=test_user",
+                "-v",
+                "{}:/certs".format(local.cwd),
+                self.image,
+                "psql",
+                "--host",
+                "example.com",
+                "--command",
+                "SELECT 1",
+                "--no-align",
+                "--tuples-only",
+            ),
+        )
 
     def test_server_certs_var(self):
         """Test server enables cert authentication through env vars."""
@@ -123,12 +151,19 @@ class PostgresAutoconfCase(unittest.TestCase):
                 self._generate_certs()
                 certs_var = {name: cat(name) for name in self.cert_files}
                 self.postgres_container = docker(
-                    "container", "run",
-                    "-d", "--network", "lan",
-                    "-e", "CERTS=" + json.dumps(certs_var),
-                    "-e", "POSTGRES_DB=test_db",
-                    "-e", "POSTGRES_PASSWORD=test_password",
-                    "-e", "POSTGRES_USER=test_user",
+                    "container",
+                    "run",
+                    "-d",
+                    "--network",
+                    "lan",
+                    "-e",
+                    "CERTS=" + json.dumps(certs_var),
+                    "-e",
+                    "POSTGRES_DB=test_db",
+                    "-e",
+                    "POSTGRES_PASSWORD=test_password",
+                    "-e",
+                    "POSTGRES_USER=test_user",
                     self.image,
                 ).strip()
                 self._check_local_connection()
@@ -150,11 +185,17 @@ class PostgresAutoconfCase(unittest.TestCase):
                     ]
                 ]
                 self.postgres_container = docker(
-                    "container", "run",
-                    "-d", "--network", "lan",
-                    "-e", "POSTGRES_DB=test_db",
-                    "-e", "POSTGRES_PASSWORD=test_password",
-                    "-e", "POSTGRES_USER=test_user",
+                    "container",
+                    "run",
+                    "-d",
+                    "--network",
+                    "lan",
+                    "-e",
+                    "POSTGRES_DB=test_db",
+                    "-e",
+                    "POSTGRES_PASSWORD=test_password",
+                    "-e",
+                    "POSTGRES_USER=test_user",
                     *cert_vols,
                     self.image,
                 ).strip()
@@ -166,11 +207,17 @@ class PostgresAutoconfCase(unittest.TestCase):
     def test_no_certs_lan(self):
         """Normal configuration without certs works fine."""
         self.postgres_container = docker(
-            "container", "run", "-d",
-            "--network", "lan",
-            "-e", "POSTGRES_DB=test_db",
-            "-e", "POSTGRES_PASSWORD=test_password",
-            "-e", "POSTGRES_USER=test_user",
+            "container",
+            "run",
+            "-d",
+            "--network",
+            "lan",
+            "-e",
+            "POSTGRES_DB=test_db",
+            "-e",
+            "POSTGRES_PASSWORD=test_password",
+            "-e",
+            "POSTGRES_USER=test_user",
             self.image,
         ).strip()
         self._check_local_connection()
@@ -182,13 +229,21 @@ class PostgresAutoconfCase(unittest.TestCase):
     def test_no_certs_wan(self):
         """Unencrypted WAN access works (although this is dangerous)."""
         self.postgres_container = docker(
-            "container", "run", "-d",
-            "--network", "lan",
-            "-e", "POSTGRES_DB=test_db",
-            "-e", "POSTGRES_PASSWORD=test_password",
-            "-e", "POSTGRES_USER=test_user",
-            "-e", "WAN_AUTH_METHOD=md5",
-            "-e", "WAN_CONNECTION=host",
+            "container",
+            "run",
+            "-d",
+            "--network",
+            "lan",
+            "-e",
+            "POSTGRES_DB=test_db",
+            "-e",
+            "POSTGRES_PASSWORD=test_password",
+            "-e",
+            "POSTGRES_USER=test_user",
+            "-e",
+            "WAN_AUTH_METHOD=md5",
+            "-e",
+            "WAN_CONNECTION=host",
             self.image,
         ).strip()
         self._check_local_connection()
@@ -200,16 +255,27 @@ class PostgresAutoconfCase(unittest.TestCase):
     def test_certs_falsy_lan(self):
         """Configuration with falsy values for certs works fine."""
         self.postgres_container = docker(
-            "container", "run", "-d",
-            "--network", "lan",
-            "-e", "POSTGRES_DB=test_db",
-            "-e", "POSTGRES_PASSWORD=test_password",
-            "-e", "POSTGRES_USER=test_user",
-            "-e", "CERTS={}".format(json.dumps({
-                "client.ca.cert.pem": False,
-                "server.cert.pem": False,
-                "server.key.pem": False,
-            })),
+            "container",
+            "run",
+            "-d",
+            "--network",
+            "lan",
+            "-e",
+            "POSTGRES_DB=test_db",
+            "-e",
+            "POSTGRES_PASSWORD=test_password",
+            "-e",
+            "POSTGRES_USER=test_user",
+            "-e",
+            "CERTS={}".format(
+                json.dumps(
+                    {
+                        "client.ca.cert.pem": False,
+                        "server.cert.pem": False,
+                        "server.key.pem": False,
+                    }
+                )
+            ),
             self.image,
         ).strip()
         self._check_local_connection()


### PR DESCRIPTION
Violating the good practice of doing just 1 thing:

1. Add pre-commit, black, isort, etc. Modern thingies! :tada: 
1. Run it for the 1st time. Ugly diff! :cry: 
1. Configure Travis to run linters. No more ugly diffs! :cake: 
1. Add tag `12-alpine`. New default! :up: 

@Tecnativa TT20468