### PR TITLE
[ADD] ci: pg17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         pg_version:
+          - "17"
           - "16"
           - "15"
           - "14"
@@ -41,7 +42,7 @@ jobs:
           - "9.6"
     env:
       # Indicates what's the equivalent to tecnativa/postgres-autoconf:latest image
-      LATEST_RELEASE: "16-alpine"
+      LATEST_RELEASE: "17-alpine"
       DOCKER_REPO: tecnativa/postgres-autoconf
       DOCKER_TAG: ${{ matrix.pg_version }}-alpine
       GIT_SHA1: ${{ github.sha }}


### PR DESCRIPTION
The latest Odoo Enterprise upgrades have begun utilizing PostgreSQL 17. Therefore, I believe it would be beneficial to incorporate support for PostgreSQL 17  here as well.

```shell
❯ head -n 10 odoo/auto/upgraded.dump/toc.dat
7GDMP
|
db_xxxxxxx 17.1 (Ubuntu 17.1-1.pgdg20.04+1) 17.0 (Ubuntu 17.0-1.pgdg20.04+1)AP<0ENCODINENCODINGSET client_encoding = 'UTF8';
falseQ<00
STDSTRINGS
STDSTRINGS(SET standard_conforming_strings = 'on';
falseR<00
SEARCHPATH
SEARCHPATH8SELECT pg_catalog.set_config('search_path', '', false);
falseS<126216394
``` 
