### PR TITLE
[FIX] pgvector files: copy extension files to /local/ folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV CERTS="{}" \
 RUN apk add --no-cache python3 py3-netifaces \
  && if [ "${PG_MAJOR:-0}" -ge 12 ]; then \
         apk add --no-cache postgresql-pgvector; \
+        cp /usr/share/postgresql/extension/vector* /usr/local/share/postgresql/extension/; \
+        cp /usr/lib/postgresql17/vector.so /usr/local/lib/postgresql/; \
     fi \
  && mkdir -p /etc/postgres \
  && chmod a=rwx /etc/postgres


### PR DESCRIPTION
pgvector library files are stored under /usr/share and /usr/lib, but postgres is looking for extension files under /usr/local/share and /usr/local/lib.

With this change we move the extension files to the expected directories.

CC @josep-tecnativa 