### PR TITLE
[FIX] Define correctly PGVECTOR_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_TAG
-ARG PGVECTOR_VERSION=0.8.1
 FROM docker.io/postgres:${BASE_TAG}
 ENTRYPOINT [ "/autoconf-entrypoint" ]
 CMD []
+ARG PGVECTOR_VERSION=0.8.1
 ENV CERTS="{}" \
     CONF_EXTRA="" \
     LAN_AUTH_METHOD=md5 \


### PR DESCRIPTION
Ensure `PGVECTOR_VERSION` is available inside the build stage to avoid empty
values during pgvector build.

Fixes [#31](https://github.com/Tecnativa/docker-postgres-autoconf/issues/31)
