### PR TITLE
[FIX] fix alpine dependencies for pg_vector compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV CERTS="{}" \
     HBA_EXTRA_RULES=""
 RUN apk add --no-cache python3 py3-netifaces \
  && if [ "${PG_MAJOR:-0}" -ge 12 ]; then \
-        apk add --no-cache --virtual .pgvector-build build-base linux-headers ca-certificates; \
+        apk add --no-cache --virtual .pgvector-build build-base clang19 llvm19 linux-headers ca-certificates; \
         wget -qO- "https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz" \
           | tar -xz -C /tmp; \
         cd "/tmp/pgvector-${PGVECTOR_VERSION}" \


### PR DESCRIPTION
I had errors when building image, leaving the image without pg_vector enabled. 
This fix the build errors