### PR TITLE
[IMP] Add ARM64 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,12 +13,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
       - name: Set PY
         run: |
           echo "PY=$(python -c 'import hashlib,sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -68,7 +68,7 @@ jobs:
         run: |
             DOCKER_REPO=${DOCKER_REPO,,}
             echo "DOCKER_REPO=$DOCKER_REPO" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
       - run: pip install -r tests/ci-requirements.txt
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,17 @@ jobs:
       - uses: pre-commit/action@v1.0.1
 
   build-test-push:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs: pre-commit
+    permissions:
+      contents: read
+      packages: write
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
     strategy:
       fail-fast: false
       matrix:
@@ -42,43 +51,55 @@ jobs:
           - "10"
           - "9.6"
     env:
+      DOCKER_PLATFORM: linux/amd64,linux/arm64
+      LOCAL_REGISTRY: localhost:5000
       # Indicates what's the equivalent to tecnativa/postgres-autoconf:latest image
       LATEST_RELEASE: "18-alpine"
-      DOCKER_REPO: tecnativa/postgres-autoconf
-      DOCKER_TAG: ${{ matrix.pg_version }}-alpine
+      DOCKER_REPO: ${{ github.repository == 'Tecnativa/docker-postgres-autoconf' && 'tecnativa/postgres-autoconf' || github.repository }}
+      BASE_TAG: ${{ matrix.pg_version }}-alpine
+      DOCKER_TAG: ${{ github.event_name == 'pull_request' && format('{0}-test-pr{1}', matrix.pg_version, github.event.number) || format('{0}-alpine', matrix.pg_version) }}
       GIT_SHA1: ${{ github.sha }}
-      IS_PR: ${{ github.event_name == 'pull_request' }}
+      # Github does not allow evaluating a secret in an if condition, so we need to set them as environment variables
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_LOGIN: ${{ secrets.DOCKERHUB_LOGIN }}
     steps:
+      # Image repo names have to be lowercase.
+      - name: Lowercase image repository name
+        run: |
+            DOCKER_REPO=${DOCKER_REPO,,}
+            echo "DOCKER_REPO=$DOCKER_REPO" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
       - run: pip install -r tests/ci-requirements.txt
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
       # Build images
-      - run: ./hooks/build
+      - name: Build images
+        run: ./hooks/build
       # Test
-      - run: python -m unittest tests.test -v
-      - name: Set Docker Tag
+      - name: Test each platform
         run: |
-          if [ "${{ env.IS_PR }}" = "true" ]; then
-            echo "DOCKER_TAG=${{ matrix.pg_version }}-test-pr${{ github.event.number }}" >> $GITHUB_ENV
-          else
-            echo "DOCKER_TAG=${{ matrix.pg_version }}-alpine" >> $GITHUB_ENV
-          fi
-      - name: Tag Docker Image for PR
-        if: env.IS_PR
-        run: docker tag ${{ env.DOCKER_REPO }}:${{ matrix.pg_version }}-alpine ${{ env.DOCKER_REPO }}:${{ env.DOCKER_TAG }}
+          IFS=',' read -ra PLATFORMS <<< "$DOCKER_PLATFORM"
+          for platform in "${PLATFORMS[@]}"; do
+            echo "Testing platform: $platform"
+            TEST_PLATFORM="$platform" python -m unittest tests.test -v
+          done
       # Push
       - name: Push Docker Image to Docker Hub
-        if: github.repository == 'Tecnativa/docker-postgres-autoconf' && (github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
+        if: env.DOCKERHUB_TOKEN && env.DOCKERHUB_LOGIN
         env:
           REGISTRY_HOST: docker.io
-          REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_LOGIN }}
+          REGISTRY_TOKEN: ${{ env.DOCKERHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ env.DOCKERHUB_LOGIN }}
         run: ./hooks/push
       - name: Push Docker Image to GitHub Registry
-        if: github.repository == 'Tecnativa/docker-postgres-autoconf' && (github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
         env:
           REGISTRY_HOST: ghcr.io
-          REGISTRY_TOKEN: ${{ secrets.BOT_TOKEN }}
-          REGISTRY_USERNAME: ${{ secrets.BOT_LOGIN }}
+          REGISTRY_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.BOT_LOGIN || github.repository_owner }}
         run: ./hooks/push

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # PostgreSQL Auto-Conf
 
-[![Build Status](https://travis-ci.org/Tecnativa/docker-postgres-autoconf.svg?branch=master)](https://travis-ci.org/Tecnativa/docker-postgres-autoconf)
+[![Build Status](../../actions/workflows/ci.yaml/badge.svg?branch=master)](../../actions/workflows/ci.yaml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/tecnativa/postgres-autoconf.svg)](https://hub.docker.com/r/tecnativa/postgres-autoconf)
-[![Layers](https://images.microbadger.com/badges/image/tecnativa/postgres-autoconf.svg)](https://microbadger.com/images/tecnativa/postgres-autoconf)
-[![Commit](https://images.microbadger.com/badges/commit/tecnativa/postgres-autoconf.svg)](https://microbadger.com/images/tecnativa/postgres-autoconf)
-[![License](https://img.shields.io/github/license/Tecnativa/docker-postgres-autoconf.svg)](https://github.com/Tecnativa/docker-postgres-autoconf/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../../blob/master/LICENSE)
 
 ## What
 

--- a/hooks/build
+++ b/hooks/build
@@ -3,24 +3,42 @@ from plumbum import FG, local
 from plumbum.cmd import date, docker
 
 # Check environment variables are present
+DOCKER_PLATFORM = local.env.get("DOCKER_PLATFORM", "linux/amd64")
 DOCKER_TAG = local.env["DOCKER_TAG"]
+BASE_TAG = local.env.get("BASE_TAG", DOCKER_TAG)
+REPO = local.env["DOCKER_REPO"]
 COMMIT = local.env.get("GIT_SHA1")
 DATE = date("--rfc-3339", "ns")
-
-# Build image
-(
-    docker[
-        "image",
-        "build",
-        "--build-arg",
-        "VCS_REF={}".format(COMMIT),
-        "--build-arg",
-        "BUILD_DATE={}".format(DATE),
-        "--build-arg",
-        "BASE_TAG={}".format(DOCKER_TAG),
-        "--tag",
-        "tecnativa/postgres-autoconf:{}".format(DOCKER_TAG),
-        ".",
-    ]
-    & FG
+LOCAL_REGISTRY = local.env.get("LOCAL_REGISTRY")
+IMAGE = (
+    "%s/%s:%s" % (LOCAL_REGISTRY, REPO, DOCKER_TAG)
+    if LOCAL_REGISTRY
+    else "%s:%s" % (REPO, DOCKER_TAG)
 )
+PLATFORMS = [p.strip() for p in DOCKER_PLATFORM.split(",") if p.strip()]
+
+build = docker[
+    "buildx",
+    "build",
+    "--platform",
+    DOCKER_PLATFORM,
+    "--build-arg",
+    "VCS_REF={}".format(COMMIT),
+    "--build-arg",
+    "BUILD_DATE={}".format(DATE),
+    "--build-arg",
+    "BASE_TAG={}".format(BASE_TAG),
+    "--tag",
+    IMAGE,
+    ".",
+]
+if LOCAL_REGISTRY:
+    build = build["--push"]
+elif len(PLATFORMS) == 1:
+    build = build["--load"]
+else:
+    raise SystemExit(
+        "Multi-platform builds require LOCAL_REGISTRY; "
+        "set DOCKER_PLATFORM to one value for local --load builds."
+    )
+(build & FG)

--- a/hooks/push
+++ b/hooks/push
@@ -7,10 +7,20 @@ REPO = local.env["DOCKER_REPO"]
 SUFFIX = local.env.get("DOCKER_REPO_SUFFIX", "")
 VERSION = local.env["DOCKER_TAG"]
 
-# Log all locally available images; will help to pin images
-docker["image", "ls", "--digests", REPO] & FG
 
-# Login in Docker Hub
+def image_ref(registry, tag):
+    return "%s/%s%s:%s" % (registry, REPO, SUFFIX, tag)
+
+
+source = image_ref(local.env["LOCAL_REGISTRY"], VERSION)
+dest_tags = [image_ref(REGISTRY, VERSION)]
+if VERSION == local.env.get("LATEST_RELEASE"):
+    latest = "alpine" if VERSION.endswith("-alpine") else "latest"
+    dest_tags.append(image_ref(REGISTRY, latest))
+
+docker["buildx", "imagetools", "inspect", source] & FG
+
+# Login in Docker Hub or ghcr
 docker(
     "login",
     "--username",
@@ -20,13 +30,7 @@ docker(
     REGISTRY,
 )
 
-# Push built images
-local_image = "%s:%s" % (REPO, VERSION)
-public_image = "%s/%s%s:%s" % (REGISTRY, REPO, SUFFIX, VERSION)
-docker["image", "tag", local_image, public_image] & FG
-docker["image", "push", public_image] & FG
-if VERSION == local.env.get("LATEST_RELEASE"):
-    latest_version = "alpine" if VERSION.endswith("-alpine") else "latest"
-    public_image = "%s/%s%s:%s" % (REGISTRY, REPO, SUFFIX, latest_version)
-    docker["image", "tag", local_image, public_image] & FG
-    docker["image", "push", public_image] & FG
+promote = docker["buildx", "imagetools", "create"]
+for dest in dest_tags:
+    promote = promote["-t", dest]
+(promote[source] & FG)

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,11 +23,18 @@ class PostgresAutoconfCase(unittest.TestCase):
     """Test behavior for this docker image"""
 
     @classmethod
+    def _platform_args(cls):
+        platform = os.environ.get("TEST_PLATFORM")
+        if platform:
+            return ("--platform", platform)
+        return ()
+
+    @classmethod
     def setUpClass(cls):
-        with local.cwd(local.cwd / ".."):
-            print("Building image")
-            local["./hooks/build"] & FG
-        cls.image = f"tecnativa/postgres-autoconf:{local.env['DOCKER_TAG']}"
+        registry = local.env.get("LOCAL_REGISTRY")
+        repo = local.env.get("DOCKER_REPO", "tecnativa/postgres-autoconf")
+        tag = local.env["DOCKER_TAG"]
+        cls.image = f"{registry}/{repo}:{tag}" if registry else f"{repo}:{tag}"
         cls.cert_files = ("client.ca.cert.pem", "server.cert.pem", "server.key.pem")
         return super().setUpClass()
 
@@ -56,7 +63,7 @@ class PostgresAutoconfCase(unittest.TestCase):
         # The 1st test could fail while postgres boots
         for attempt in range(10):
             try:
-                time.sleep(5)
+                time.sleep(15)
                 # Test local connections via unix socket work
                 self.assertEqual(
                     "1\n",
@@ -75,13 +82,13 @@ class PostgresAutoconfCase(unittest.TestCase):
                         "test_user",
                     ),
                 )
-            except AssertionError:
+            except (AssertionError, ProcessExecutionError):
                 if attempt < 9:
                     print("Failure number {}. Retrying...".format(attempt))
                 else:
                     raise
             else:
-                continue
+                return
 
     def _check_password_auth(self, host=None):
         """Test connection with password auth work fine."""
@@ -93,6 +100,7 @@ class PostgresAutoconfCase(unittest.TestCase):
             docker(
                 "container",
                 "run",
+                *self._platform_args(),
                 "--network",
                 "lan",
                 "-e",
@@ -126,6 +134,7 @@ class PostgresAutoconfCase(unittest.TestCase):
             docker(
                 "container",
                 "run",
+                *self._platform_args(),
                 "--network",
                 "wan",
                 "-e",
@@ -163,6 +172,7 @@ class PostgresAutoconfCase(unittest.TestCase):
                 self.postgres_container = docker(
                     "container",
                     "run",
+                    *self._platform_args(),
                     "-d",
                     "--network",
                     "lan",
@@ -198,6 +208,7 @@ class PostgresAutoconfCase(unittest.TestCase):
                 self.postgres_container = docker(
                     "container",
                     "run",
+                    *self._platform_args(),
                     "-d",
                     "--network",
                     "lan",
@@ -221,6 +232,7 @@ class PostgresAutoconfCase(unittest.TestCase):
         self.postgres_container = docker(
             "container",
             "run",
+            *self._platform_args(),
             "-d",
             "--network",
             "lan",
@@ -244,6 +256,7 @@ class PostgresAutoconfCase(unittest.TestCase):
         self.postgres_container = docker(
             "container",
             "run",
+            *self._platform_args(),
             "-d",
             "--network",
             "lan",
@@ -271,6 +284,7 @@ class PostgresAutoconfCase(unittest.TestCase):
         self.postgres_container = docker(
             "container",
             "run",
+            *self._platform_args(),
             "-d",
             "--network",
             "lan",
@@ -312,6 +326,7 @@ class PostgresAutoconfCase(unittest.TestCase):
         # Start the Postgres container with HBA_EXTRA_RULES
         self.postgres_container = docker(
             "run",
+            *self._platform_args(),
             "-d",
             "--name",
             "postgres_test_hba_extra_rules",


### PR DESCRIPTION
This PR changes the CI to build multiarch images; currently AMD64 and ARM64 and ensures tests are run on every architecture using QEMU.
It also makes the CI much more repo agnostic so that forks can run these actions in their own repo and push to their own registry with little to no customization.
Finally, I cleaned up the badges in the readme as several of them were no longer in use and also bumped the versions on the `actions/checkout` and `actions/cache` actions in order to stop triggering the Node.js 20 deprecation warnings

For reference:
It appears that an attempt to build for ARM64 has been made before as #17 and #18 and mentioned in #16, but was mixed in with introducing PG 16 and so went by the wayside.
