### PR TITLE
Fix clang/llvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,11 @@ ENV CERTS="{}" \
     WAN_USERS='["all"]' \
     HBA_EXTRA_RULES=""
 RUN apk add --no-cache python3 py3-netifaces \
- && if [ "${PG_MAJOR:-0}" -ge 12 ]; then \
-        apk add --no-cache --virtual .pgvector-build build-base clang19 llvm19 linux-headers ca-certificates; \
+ && if [ "${PG_MAJOR:-0}" -ge 13 ]; then \
+        PG_CLANG="$(pg_config --configure | tr "'" "\n" | sed -n 's/^CLANG=clang-//p')"; \
+        PG_LLVM="$(pg_config --configure | tr "'" "\n" | sed -n 's#^LLVM_CONFIG=/usr/lib/llvm\([0-9][0-9]*\)/bin/llvm-config#\1#p')"; \
+        test -n "${PG_CLANG}" && test -n "${PG_LLVM}" && test "${PG_CLANG}" = "${PG_LLVM}"; \
+        apk add --no-cache --virtual .pgvector-build build-base linux-headers ca-certificates "clang${PG_CLANG}" "llvm${PG_LLVM}"; \
         wget -qO- "https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz" \
           | tar -xz -C /tmp; \
         cd "/tmp/pgvector-${PGVECTOR_VERSION}" \

--- a/tests/test.py
+++ b/tests/test.py
@@ -356,6 +356,73 @@ class PostgresAutoconfCase(unittest.TestCase):
         for rule in hba_extra_rules:
             self.assertIn(rule, hba_conf)
 
+    def test_pgvector_extension(self):
+        """Test that pgvector is installed and works."""
+        if float(local.env["DOCKER_TAG"].split("-")[0]) < 13:
+            self.skipTest("pgvector not built for PostgreSQL < 13")
+        self.postgres_container = docker(
+            "container",
+            "run",
+            "-d",
+            "--network",
+            "lan",
+            "-e",
+            "POSTGRES_DB=test_db",
+            "-e",
+            "POSTGRES_PASSWORD=test_password",
+            "-e",
+            "POSTGRES_USER=test_user",
+            CONF_EXTRA,
+            self.image,
+        ).strip()
+        self._check_local_connection()
+        self.assertEqual(
+            "vector\n",
+            docker(
+                "container",
+                "exec",
+                self.postgres_container,
+                "psql",
+                "--command",
+                "SELECT name FROM pg_available_extensions WHERE name = 'vector';",
+                "--dbname",
+                "test_db",
+                "--no-align",
+                "--tuples-only",
+                "--username",
+                "test_user",
+            ),
+        )
+        docker(
+            "container",
+            "exec",
+            self.postgres_container,
+            "psql",
+            "--command",
+            "CREATE EXTENSION vector;",
+            "--dbname",
+            "test_db",
+            "--username",
+            "test_user",
+        )
+        self.assertEqual(
+            "1\n",
+            docker(
+                "container",
+                "exec",
+                self.postgres_container,
+                "psql",
+                "--command",
+                "SELECT ('[1,2,3]'::vector <-> '[1,2,4]'::vector)::int;",
+                "--dbname",
+                "test_db",
+                "--no-align",
+                "--tuples-only",
+                "--username",
+                "test_user",
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Base for Postgres 14-18 was bumped from alpine v3.23 to v3.24 in https://github.com/docker-library/official-images/commit/769849fad2de6478192bc0dc31a2803fe422f07b

Alpine v3.24 dropped support for clang19/llvm19, which caused pgvector-build to fail for versions 14 and up.

On investigation, it turns out that it was impossible to use just one version of clang and llvm because in alpine-12 the highest version is still clang19.

The simplest solution is to just loop over the versions from the top down. I even added version 23, which does not exist yet, but will defer the necessity of doing this again for a while