### PR TITLE
Bump pgvector to 0.8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_TAG
 FROM docker.io/postgres:${BASE_TAG}
 ENTRYPOINT [ "/autoconf-entrypoint" ]
 CMD []
-ARG PGVECTOR_VERSION=0.8.1
+ARG PGVECTOR_VERSION=0.8.4
 ENV CERTS="{}" \
     CONF_EXTRA="" \
     LAN_AUTH_METHOD=md5 \


### PR DESCRIPTION
As requested in https://github.com/Tecnativa/docker-postgres-autoconf/pull/40#discussion_r3529543450

This should not be a breaking change, but does need an [upgrade](https://github.com/pgvector/pgvector#upgrading):
[Install](https://github.com/pgvector/pgvector#installation) the latest version (use the same method as the original installation). Then in each database you want to upgrade, run:
```
ALTER EXTENSION vector UPDATE;
```

However, I have not tested this myself